### PR TITLE
Add TMP119 subclass with 0x2117 device ID

### DIFF
--- a/Adafruit_TMP117.cpp
+++ b/Adafruit_TMP117.cpp
@@ -394,14 +394,20 @@ bool Adafruit_TMP117::setMeasurementMode(tmp117_mode_t mode) {
       Adafruit_BusIO_RegisterBits(config_reg, 2, 10);
   return mode_bits.write(mode);
 }
-///////////////////  Misc private methods //////////////////////////////
+///////////////////  Misc methods //////////////////////////////
 void Adafruit_TMP117::waitForData(void) {
-  while (!getDataReady()) {
+  while (!dataReady()) {
     delay(1);
   }
 }
 
-bool Adafruit_TMP117::getDataReady(void) {
+/**
+ * @brief Check if new temperature data is ready
+ *
+ * @return true New data is available
+ * @return false No new data available yet
+ */
+bool Adafruit_TMP117::dataReady(void) {
   readAlertsDRDY();
   return alert_drdy_flags.data_ready;
 }

--- a/Adafruit_TMP117.h
+++ b/Adafruit_TMP117.h
@@ -167,14 +167,9 @@ public:
   tmp117_mode_t getMeasurementMode(void);
   bool setMeasurementMode(tmp117_mode_t mode);
 
-private:
-  // void _read(void);
-  bool _init(int32_t sensor_id);
+protected:
+  virtual bool _init(int32_t sensor_id);
   uint16_t _sensorid_temp; ///< ID number for temperature
-
-  tmp117_alerts_t
-      alert_drdy_flags; ///< Storage for self-cleared bits in config reg.
-  float unscaled_temp;  ///< Last reading's temperature (C) before scaling
 
   Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
   Adafruit_BusIO_Register *config_reg =
@@ -182,9 +177,15 @@ private:
   Adafruit_BusIO_Register *temp_reg =
       NULL; ///< Temperature register, used regularly
 
+  void waitForData(void);
+
+private:
+  tmp117_alerts_t
+      alert_drdy_flags; ///< Storage for self-cleared bits in config reg.
+  float unscaled_temp;  ///< Last reading's temperature (C) before scaling
+
   void readAlertsDRDY(void);
   bool getDataReady(void);
-  void waitForData(void);
 };
 
 #endif

--- a/Adafruit_TMP117.h
+++ b/Adafruit_TMP117.h
@@ -167,6 +167,8 @@ public:
   tmp117_mode_t getMeasurementMode(void);
   bool setMeasurementMode(tmp117_mode_t mode);
 
+  bool dataReady(void);
+
 protected:
   virtual bool _init(int32_t sensor_id);
   uint16_t _sensorid_temp; ///< ID number for temperature
@@ -177,6 +179,7 @@ protected:
   Adafruit_BusIO_Register *temp_reg =
       NULL; ///< Temperature register, used regularly
 
+  /*! @brief Block until new data is ready */
   void waitForData(void);
 
 private:
@@ -185,7 +188,6 @@ private:
   float unscaled_temp;  ///< Last reading's temperature (C) before scaling
 
   void readAlertsDRDY(void);
-  bool getDataReady(void);
 };
 
 #endif

--- a/Adafruit_TMP119.cpp
+++ b/Adafruit_TMP119.cpp
@@ -1,0 +1,72 @@
+/*!
+ *  @file Adafruit_TMP119.cpp
+ *
+ *  @brief I2C Driver for the TMP119 High-Accuracy Temperature Sensor
+ *
+ *  This is a library for the TMP119 temperature sensor, which is a variant
+ *  of the TMP117 with a different chip ID (0x2117 instead of 0x0117).
+ *
+ *  Adafruit invests time and resources providing this open source code.
+ *  Please support Adafruit and open-source hardware by purchasing products from
+ *  Adafruit!
+ *
+ *  BSD (see license.txt)
+ */
+
+#include "Adafruit_TMP119.h"
+
+/**
+ * @brief Construct a new Adafruit_TMP119::Adafruit_TMP119 object
+ *
+ */
+Adafruit_TMP119::Adafruit_TMP119(void) : Adafruit_TMP117() {}
+
+/**
+ * @brief Sets up the hardware and initializes I2C
+ *
+ * @param i2c_address The I2C address to be used.
+ * @param wire The Wire object to be used for I2C connections.
+ * @param sensor_id The unique ID to differentiate the sensors from others
+ * @return True if initialization was successful, otherwise false.
+ */
+bool Adafruit_TMP119::begin(uint8_t i2c_address, TwoWire *wire,
+                            int32_t sensor_id) {
+  i2c_dev = new Adafruit_I2CDevice(i2c_address, wire);
+
+  if (!i2c_dev->begin()) {
+    return false;
+  }
+
+  return _init(sensor_id);
+}
+
+/**
+ * @brief Initializer for post bus-init setup (TMP119 variant)
+ *
+ * @param sensor_id Optional unique ID for the sensor set
+ * @return True if chip identified and initialized
+ */
+bool Adafruit_TMP119::_init(int32_t sensor_id) {
+  Adafruit_BusIO_Register chip_id =
+      Adafruit_BusIO_Register(i2c_dev, TMP117_WHOAMI, 2, MSBFIRST);
+
+  // make sure we're talking to the right chip (TMP119 has ID 0x2117)
+  uint8_t buffer[2];
+  chip_id.read(buffer, 2);
+  if ((buffer[0] << 8 | buffer[1]) != TMP119_CHIP_ID) {
+    return false;
+  }
+
+  _sensorid_temp = sensor_id;
+
+  // do any software reset or other initial setup
+  config_reg =
+      new Adafruit_BusIO_Register(i2c_dev, TMP117_CONFIGURATION, 2, MSBFIRST);
+
+  temp_reg =
+      new Adafruit_BusIO_Register(i2c_dev, TMP117_TEMP_DATA, 2, MSBFIRST);
+
+  reset();
+
+  return true;
+}

--- a/Adafruit_TMP119.h
+++ b/Adafruit_TMP119.h
@@ -1,0 +1,35 @@
+/*!
+ *  @file Adafruit_TMP119.h
+ *
+ *  I2C Driver for the TMP119 high-accuracy temperature sensor
+ *  This is a library written to work with the Adafruit TMP119 breakout.
+ *
+ *  Adafruit invests time and resources providing this open source code,
+ *  please support Adafruit and open-source hardware by purchasing products from
+ *  Adafruit!
+ *
+ *  BSD license (see license.txt)
+ */
+
+#ifndef _ADAFRUIT_TMP119_H
+#define _ADAFRUIT_TMP119_H
+
+#include "Adafruit_TMP117.h"
+
+#define TMP119_CHIP_ID 0x2117 ///< TMP119 device id
+
+/*!
+ *    @brief  Class that stores state and functions for interacting with
+ *            the TMP119 High-Accuracy Temperature Sensor
+ */
+class Adafruit_TMP119 : public Adafruit_TMP117 {
+public:
+  Adafruit_TMP119();
+  bool begin(uint8_t i2c_addr = TMP117_I2CADDR_DEFAULT, TwoWire *wire = &Wire,
+             int32_t sensor_id = 119);
+
+protected:
+  bool _init(int32_t sensor_id) override;
+};
+
+#endif

--- a/examples/TMP119_basic_test/TMP119_basic_test.ino
+++ b/examples/TMP119_basic_test/TMP119_basic_test.ino
@@ -1,0 +1,41 @@
+/**
+ * @file TMP119_basic_test.ino
+ * @brief Basic test sketch for the TMP119 temperature sensor
+ * @date 2025-02-25
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+#include <Adafruit_Sensor.h>
+#include <Adafruit_TMP119.h>
+#include <Wire.h>
+
+Adafruit_TMP119 tmp119;
+
+void setup(void) {
+  Serial.begin(115200);
+  while (!Serial)
+    delay(10); // will pause Zero, Leonardo, etc until serial console opens
+  Serial.println(F("Adafruit TMP119 test!"));
+
+  // Try to initialize!
+  if (!tmp119.begin()) {
+    Serial.println(F("Failed to find TMP119 chip"));
+    while (1) {
+      delay(10);
+    }
+  }
+  Serial.println(F("TMP119 Found!"));
+}
+
+void loop() {
+  sensors_event_t temp; // create an empty event to be filled
+  tmp119.getEvent(
+      &temp); // fill the empty event object with the current measurements
+  Serial.print(F("Temperature  "));
+  Serial.print(temp.temperature);
+  Serial.println(F(" degrees C"));
+  Serial.println();
+
+  delay(1000);
+}

--- a/examples/TMP119_basic_test/TMP119_basic_test.ino
+++ b/examples/TMP119_basic_test/TMP119_basic_test.ino
@@ -11,11 +11,11 @@
 #include <Adafruit_TMP119.h>
 #include <Wire.h>
 
-// Adafruit_TMP117 tmp117;
-Adafruit_TMP119 tmp119;
+// Adafruit_TMP117 tmp11x;
+Adafruit_TMP119 tmp11x;
 
-// To use with TMP117 instead, uncomment the TMP117 lines above
-// and comment out the TMP119 lines, then replace tmp119 with tmp117 below
+// To use with TMP117 instead, uncomment the TMP117 include/line above
+// and comment out the TMP119 include/line
 
 void setup(void) {
   Serial.begin(115200);
@@ -24,7 +24,7 @@ void setup(void) {
   Serial.println(F("Adafruit TMP119 test!"));
 
   // Try to initialize!
-  if (!tmp119.begin()) {
+  if (!tmp11x.begin()) {
     Serial.println(F("Failed to find TMP119 chip"));
     while (1) {
       delay(10);
@@ -35,7 +35,7 @@ void setup(void) {
 
 void loop() {
   sensors_event_t temp; // create an empty event to be filled
-  tmp119.getEvent(
+  tmp11x.getEvent(
       &temp); // fill the empty event object with the current measurements
   Serial.print(F("Temperature  "));
   Serial.print(temp.temperature);

--- a/examples/TMP119_basic_test/TMP119_basic_test.ino
+++ b/examples/TMP119_basic_test/TMP119_basic_test.ino
@@ -34,6 +34,11 @@ void setup(void) {
 }
 
 void loop() {
+  // Wait for fresh data before reading
+  while (!tmp11x.dataReady()) {
+    delay(10);
+  }
+
   sensors_event_t temp; // create an empty event to be filled
   tmp11x.getEvent(
       &temp); // fill the empty event object with the current measurements

--- a/examples/TMP119_basic_test/TMP119_basic_test.ino
+++ b/examples/TMP119_basic_test/TMP119_basic_test.ino
@@ -1,16 +1,21 @@
 /**
  * @file TMP119_basic_test.ino
- * @brief Basic test sketch for the TMP119 temperature sensor
+ * @brief Basic test sketch for the TMP117/TMP119 temperature sensor
  * @date 2025-02-25
  *
  * @copyright Copyright (c) 2025
  *
  */
 #include <Adafruit_Sensor.h>
+// #include <Adafruit_TMP117.h>
 #include <Adafruit_TMP119.h>
 #include <Wire.h>
 
+// Adafruit_TMP117 tmp117;
 Adafruit_TMP119 tmp119;
+
+// To use with TMP117 instead, uncomment the TMP117 lines above
+// and comment out the TMP119 lines, then replace tmp119 with tmp117 below
 
 void setup(void) {
   Serial.begin(115200);

--- a/examples/alerts/alerts.ino
+++ b/examples/alerts/alerts.ino
@@ -15,11 +15,11 @@
 
 Adafruit_SSD1306 display = Adafruit_SSD1306(128, 32, &Wire);
 
-Adafruit_TMP117 tmp117;
-// Adafruit_TMP119 tmp119;
+Adafruit_TMP117 tmp11x;
+// Adafruit_TMP119 tmp11x;
 
-// To use with TMP119 instead, uncomment the TMP119 lines above
-// and comment out the TMP117 lines, then replace tmp117 with tmp119 below
+// To use with TMP119 instead, uncomment the TMP119 include/line above
+// and comment out the TMP117 include/line
 void setup(void) {
   Serial.begin(115200);
   while (!Serial)
@@ -27,7 +27,7 @@ void setup(void) {
   Serial.println("Adafruit TMP117 test!");
 
   // Try to initialize!
-  if (!tmp117.begin()) {
+  if (!tmp11x.begin()) {
     Serial.println("Failed to find TMP117 chip");
     while (1) {
       delay(10);
@@ -49,9 +49,9 @@ void setup(void) {
   // Set the enable flag below to see how the low temp limit can be used as a
   // hysteresis value that defines the acceptable range for the temperature values where
   // the high temp alert is not active
-  // tmp117.thermAlertModeEnabled(true);
+  // tmp11x.thermAlertModeEnabled(true);
   Serial.print("Therm mode enabled: ");
-  if (tmp117.thermAlertModeEnabled()) {
+  if (tmp11x.thermAlertModeEnabled()) {
     Serial.println("True");
   } else {
     Serial.println("False");
@@ -59,13 +59,13 @@ void setup(void) {
 
   // You may need to adjust these thresholds to fit the temperature range of where the test is
   // being run to be able to see the alert status change.
-  tmp117.setHighThreshold(35.0);
-  Serial.print("High threshold: "); Serial.println(tmp117.getHighThreshold(), 1);
-  tmp117.setLowThreshold(28.5);
-  Serial.print("Low threshold: "); Serial.println(tmp117.getLowThreshold(), 1);
+  tmp11x.setHighThreshold(35.0);
+  Serial.print("High threshold: "); Serial.println(tmp11x.getHighThreshold(), 1);
+  tmp11x.setLowThreshold(28.5);
+  Serial.print("Low threshold: "); Serial.println(tmp11x.getLowThreshold(), 1);
 
-  // tmp117.interruptsActiveLow(false);
-  if(tmp117.interruptsActiveLow()){
+  // tmp11x.interruptsActiveLow(false);
+  if(tmp11x.interruptsActiveLow()){
     Serial.println("Alerts are active when the INT pin is LOW");
   } else {
     Serial.println("Alerts are active when the INT pin is HIGH");
@@ -82,8 +82,8 @@ void loop() {
   tmp117_alerts_t alerts;
   sensors_event_t temp;
   // Reading temp clears alerts, so read alerts first
-  tmp117.getAlerts(&alerts); // get the status of any alerts
-  tmp117.getEvent(&temp);   // get temperature
+  tmp11x.getAlerts(&alerts); // get the status of any alerts
+  tmp11x.getEvent(&temp);   // get temperature
 
   Serial.print("Temperature: ");
   Serial.print(temp.temperature);

--- a/examples/alerts/alerts.ino
+++ b/examples/alerts/alerts.ino
@@ -1,20 +1,25 @@
 /**
  * @file alerts.ino
  * @author Bryan Siepert for Adafruit Industries
- * @brief Show how to set adjust and use the sensor's included alert settings
+ * @brief Show how to set adjust and use the TMP117/TMP119 alert settings
  * @date 2020-11-10
- * 
+ *
  * @copyright Copyright (c) 2020
- * 
+ *
  */
 #include <Adafruit_SSD1306.h>
 #include <Adafruit_Sensor.h>
 #include <Adafruit_TMP117.h>
+// #include <Adafruit_TMP119.h>
 #include <Wire.h>
 
 Adafruit_SSD1306 display = Adafruit_SSD1306(128, 32, &Wire);
 
 Adafruit_TMP117 tmp117;
+// Adafruit_TMP119 tmp119;
+
+// To use with TMP119 instead, uncomment the TMP119 lines above
+// and comment out the TMP117 lines, then replace tmp117 with tmp119 below
 void setup(void) {
   Serial.begin(115200);
   while (!Serial)

--- a/examples/basic_test/basic_test.ino
+++ b/examples/basic_test/basic_test.ino
@@ -12,18 +12,18 @@
 // #include <Adafruit_TMP119.h>
 #include <Wire.h>
 
-Adafruit_TMP117 tmp117;
-// Adafruit_TMP119 tmp119;
+Adafruit_TMP117 tmp11x;
+// Adafruit_TMP119 tmp11x;
 
-// To use with TMP119 instead, uncomment the TMP119 lines above
-// and comment out the TMP117 lines, then replace tmp117 with tmp119 below
+// To use with TMP119 instead, uncomment the TMP119 include/line above
+// and comment out the TMP117 include/line
 void setup(void) {
   Serial.begin(115200);
   while (!Serial) delay(10);     // will pause Zero, Leonardo, etc until serial console opens
   Serial.println("Adafruit TMP117 test!");
 
   // Try to initialize!
-  if (!tmp117.begin()) {
+  if (!tmp11x.begin()) {
     Serial.println("Failed to find TMP117 chip");
     while (1) { delay(10); }
   }
@@ -33,7 +33,7 @@ void setup(void) {
 void loop() {
 
   sensors_event_t temp; // create an empty event to be filled
-  tmp117.getEvent(&temp); //fill the empty event object with the current measurements
+  tmp11x.getEvent(&temp); //fill the empty event object with the current measurements
   Serial.print("Temperature  "); Serial.print(temp.temperature);Serial.println(" degrees C");
   Serial.println("");
 

--- a/examples/basic_test/basic_test.ino
+++ b/examples/basic_test/basic_test.ino
@@ -31,6 +31,10 @@ void setup(void) {
 
 }
 void loop() {
+  // Wait for fresh data before reading
+  while (!tmp11x.dataReady()) {
+    delay(10);
+  }
 
   sensors_event_t temp; // create an empty event to be filled
   tmp11x.getEvent(&temp); //fill the empty event object with the current measurements

--- a/examples/basic_test/basic_test.ino
+++ b/examples/basic_test/basic_test.ino
@@ -1,17 +1,22 @@
 /**
  * @file basic_test.ino
  * @author Bryan Siepert for Adafruit Industries
- * @brief Shows how to specify a
+ * @brief Basic temperature reading example for TMP117/TMP119
  * @date 2020-11-10
- * 
+ *
  * @copyright Copyright (c) 2020
- * 
+ *
  */
-#include <Wire.h>
-#include <Adafruit_TMP117.h>
 #include <Adafruit_Sensor.h>
+#include <Adafruit_TMP117.h>
+// #include <Adafruit_TMP119.h>
+#include <Wire.h>
 
-Adafruit_TMP117  tmp117;
+Adafruit_TMP117 tmp117;
+// Adafruit_TMP119 tmp119;
+
+// To use with TMP119 instead, uncomment the TMP119 lines above
+// and comment out the TMP117 lines, then replace tmp117 with tmp119 below
 void setup(void) {
   Serial.begin(115200);
   while (!Serial) delay(10);     // will pause Zero, Leonardo, etc until serial console opens

--- a/examples/measurement_settings/measurement_settings.ino
+++ b/examples/measurement_settings/measurement_settings.ino
@@ -1,21 +1,25 @@
 /**
- * @file average_counts.ino
+ * @file measurement_settings.ino
  * @author Bryan Siepert for Adafruit Industries
- * @brief Demonstrates the different settings that can be adjusted to
- * change the behavior of the sensor, including measurement averaging,
+ * @brief Demonstrates the different TMP117/TMP119 settings that can be adjusted
+ * to change the behavior of the sensor, including measurement averaging,
  * interval between readings, setting an offset, and measurement mode
  * @date 2020-11-10
- * 
+ *
  * @copyright Copyright (c) 2020
- * 
+ *
  */
 
-#include <Wire.h>
-#include <Adafruit_TMP117.h>
 #include <Adafruit_Sensor.h>
+#include <Adafruit_TMP117.h>
+// #include <Adafruit_TMP119.h>
+#include <Wire.h>
 
+Adafruit_TMP117 tmp117;
+// Adafruit_TMP119 tmp119;
 
-Adafruit_TMP117  tmp117;
+// To use with TMP119 instead, uncomment the TMP119 lines above
+// and comment out the TMP117 lines, then replace tmp117 with tmp119 below
 void setup(void) {
   Serial.begin(115200);
   while (!Serial) delay(10);     // will pause Zero, Leonardo, etc until serial console opens

--- a/examples/measurement_settings/measurement_settings.ino
+++ b/examples/measurement_settings/measurement_settings.ino
@@ -15,18 +15,18 @@
 // #include <Adafruit_TMP119.h>
 #include <Wire.h>
 
-Adafruit_TMP117 tmp117;
-// Adafruit_TMP119 tmp119;
+Adafruit_TMP117 tmp11x;
+// Adafruit_TMP119 tmp11x;
 
-// To use with TMP119 instead, uncomment the TMP119 lines above
-// and comment out the TMP117 lines, then replace tmp117 with tmp119 below
+// To use with TMP119 instead, uncomment the TMP119 include/line above
+// and comment out the TMP117 include/line
 void setup(void) {
   Serial.begin(115200);
   while (!Serial) delay(10);     // will pause Zero, Leonardo, etc until serial console opens
   Serial.println("Adafruit TMP117 settings example");
 
   // Try to initialize!
-  if (!tmp117.begin()) {
+  if (!tmp11x.begin()) {
     Serial.println("Failed to find TMP117 chip");
     while (1) { delay(10); }
   }
@@ -35,9 +35,9 @@ void setup(void) {
   // Raising the number of averaged temperature samples (individual measurements) will make
   // measurements take longer but will make them less sensitive to quick, temporary changes.
 
-  // tmp117.setAveragedSampleCount(TMP117_AVERAGE_32X);
+  // tmp11x.setAveragedSampleCount(TMP117_AVERAGE_32X);
   Serial.print("Temperature averaged from ");
-  switch(tmp117.getAveragedSampleCount()){
+  switch(tmp11x.getAveragedSampleCount()){
     case TMP117_AVERAGE_1X: Serial.print(" 1");break;
     case TMP117_AVERAGE_8X: Serial.print(" 8");break;
     case TMP117_AVERAGE_32X: Serial.print(" 32");break;
@@ -50,9 +50,9 @@ void setup(void) {
   // when the temperature is being changed by a heater or cooler, less time between readings  will
   // allow you to know more accurately when the temperature is at a given value.
 
-  // tmp117.setReadDelay(TMP117_DELAY_125_MS);
+  // tmp11x.setReadDelay(TMP117_DELAY_125_MS);
   Serial.print("Interval between reads is at least ");
-  switch(tmp117.getReadDelay()){
+  switch(tmp11x.getReadDelay()){
     case TMP117_DELAY_0_MS: Serial.print(0); break;
     case TMP117_DELAY_125_MS: Serial.print(125); break;
     case TMP117_DELAY_250_MS: Serial.print(250); break;
@@ -68,9 +68,9 @@ void setup(void) {
   // Since you can turn it off when not used!
 
   // Set a mode; other options are below (TMP117_MODE...) or can be found in the documentation
-  // tmp117.setMeasurementMode(TMP117_MODE_SHUTDOWN);
+  // tmp11x.setMeasurementMode(TMP117_MODE_SHUTDOWN);
   Serial.print("Measurement mode: ");
-  switch(tmp117.getMeasurementMode()){
+  switch(tmp11x.getMeasurementMode()){
     case TMP117_MODE_SHUTDOWN: Serial.println("Shut down"); break;
     // This will almost never be read because of the switch to SHUTDOWN after the measurement is
     // taken.
@@ -81,11 +81,11 @@ void setup(void) {
   // Set a positive or negative offset here to see how it changes the measured values.
   // A temperature offset can be used to adjust for a static bias in measuremets
 
-  // tmp117.setOffset(10.4f);
-  float temp_offset = tmp117.getOffset();
+  // tmp11x.setOffset(10.4f);
+  float temp_offset = tmp11x.getOffset();
   if (temp_offset != 0){
     sensors_event_t temp;
-    tmp117.getEvent(&temp);// get temperature
+    tmp11x.getEvent(&temp);// get temperature
     Serial.print("Temperature without offset:"); Serial.print(temp.temperature);Serial.println(" C");
     Serial.println("");
     Serial.print("Temperatures with offset of "); Serial.print(temp_offset, 1); Serial.println(" C:");
@@ -97,7 +97,7 @@ void setup(void) {
 void loop() {
 
   sensors_event_t temp;
-  tmp117.getEvent(&temp);// get temperature
+  tmp11x.getEvent(&temp);// get temperature
   Serial.print("Temperature: ");Serial.print(temp.temperature);Serial.println(" degrees C");
   Serial.println("");
 

--- a/examples/oled_test/oled_test.ino
+++ b/examples/oled_test/oled_test.ino
@@ -1,20 +1,24 @@
-
 /**
  * @file oled_test.ino
  * @author Bryan Siepert for Adafruit Industries
- * @brief A simple demo that displays the measurements and alert status to
- * an attached 128x32 OLED screen
+ * @brief A simple demo that displays TMP117/TMP119 measurements and alert
+ * status to an attached 128x32 OLED screen
  * @date 2020-11-10
  *
  * @copyright Copyright (c) 2020
  *
  */
-#include <Adafruit_TMP117.h>
 #include <Adafruit_SSD1306.h>
+#include <Adafruit_TMP117.h>
+// #include <Adafruit_TMP119.h>
 
 Adafruit_SSD1306 display = Adafruit_SSD1306(128, 32, &Wire);
 
-Adafruit_TMP117  tmp117;
+Adafruit_TMP117 tmp117;
+// Adafruit_TMP119 tmp119;
+
+// To use with TMP119 instead, uncomment the TMP119 lines above
+// and comment out the TMP117 lines, then replace tmp117 with tmp119 below
 void setup(void) {
   Serial.begin(115200);
 

--- a/examples/oled_test/oled_test.ino
+++ b/examples/oled_test/oled_test.ino
@@ -14,11 +14,11 @@
 
 Adafruit_SSD1306 display = Adafruit_SSD1306(128, 32, &Wire);
 
-Adafruit_TMP117 tmp117;
-// Adafruit_TMP119 tmp119;
+Adafruit_TMP117 tmp11x;
+// Adafruit_TMP119 tmp11x;
 
-// To use with TMP119 instead, uncomment the TMP119 lines above
-// and comment out the TMP117 lines, then replace tmp117 with tmp119 below
+// To use with TMP119 instead, uncomment the TMP119 include/line above
+// and comment out the TMP117 include/line
 void setup(void) {
   Serial.begin(115200);
 
@@ -27,7 +27,7 @@ void setup(void) {
   Serial.println("Adafruit TMP117 test!");
 
   // Try to initialize!
-  if (!tmp117.begin()) {
+  if (!tmp11x.begin()) {
     Serial.println("Failed to find TMP117 chip");
     while (1) { delay(10); }
   }
@@ -54,8 +54,8 @@ void loop() {
   sensors_event_t temp;
 
   // Reading temp clears alerts, so read alerts first
-  tmp117.getAlerts(&alerts);
-  tmp117.getEvent(&temp);
+  tmp11x.getAlerts(&alerts);
+  tmp11x.getEvent(&temp);
 
   Serial.print("Temperature: ");
   Serial.print(temp.temperature);

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Adafruit TMP117
-version=1.0.3
+version=1.0.4
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
-sentence=Arduino library for the TMP117 sensors in the Adafruit shop
-paragraph=Arduino library for the TMP117 sensors in the Adafruit shop
+sentence=Arduino library for the TMP117 and TMP119 sensors in the Adafruit shop
+paragraph=Arduino library for the TMP117 and TMP119 high-accuracy temperature sensors in the Adafruit shop
 category=Sensors
 url=https://github.com/adafruit/Adafruit_TMP117
 architectures=*


### PR DESCRIPTION
Adds support for the TI TMP119, which is a higher-accuracy variant of the TMP117. The TMP119 shares the same register map and resolution but reports a different device ID (0x2117 vs 0x0117).

**Changes:**
- `Adafruit_TMP119.h` / `Adafruit_TMP119.cpp` — subclass of `Adafruit_TMP117` that overrides the ID check for 0x2117
- Base class: moved key members to `protected` and made `_init()` virtual to support subclassing
- New `examples/TMP119_basic_test` example
- Updated `library.properties` to mention TMP119

**Tested on hardware:** Metro Mini + TMP119, reads temperature correctly (~23°C room temp).